### PR TITLE
Add optional authentication for HTTP endpoints

### DIFF
--- a/src/DayClock/Config.h
+++ b/src/DayClock/Config.h
@@ -1,13 +1,15 @@
 #pragma once
 
-//#define DISPLAY_CELSIUS                         // Uncomment if you want the LCD and HTTP displays to default to Celsius temperature instead of Fahrenheit
-#define UDP_HOST_IP            192,168,0,1        // IP address, comma separated (eg: 192,168,0,1), if you want to receive UDP push messages.
-#define UDP_HOST_PORT          1234               // UDP port
-const char *ssid               = "YOUR_SSID";     // Your WiFi SSID
-const char *password           = "PASSWORD";      // Your WiFi password
-const char* ntpServer          = "pool.ntp.org";  // There are also region-specific addresses such as "us.pool.ntp.org"
-const long  gmtOffset_sec      = -21600;          // Non-daylight saving time offset from UTC, in seconds (-18000 = US Eastern Standard Time, -21600 = US Central Standard Time, etc.)
-const int   daylightOffset_sec = 3600;            // Number of seconds offset for daylight saving time (0 if daylight savings time if not applicable)
+//#define DISPLAY_CELSIUS                                   // Uncomment if you want the LCD and HTTP displays to default to Celsius temperature instead of Fahrenheit
+#define UDP_HOST_IP              192,168,0,1                // IP address, comma separated (eg: 192,168,0,1), if you want to receive UDP push messages.
+#define UDP_HOST_PORT            1234                       // UDP port
+const char *ssid                 = "YOUR_SSID";             // Your WiFi SSID
+const char *password             = "PASSWORD";              // Your WiFi password
+const char *ntpServer            = "ntp.pool.org";          // There are also region-specific addresses such as "us.pool.ntp.org"
+const long  gmtOffset_sec        = -21600;                  // Non-daylight saving time offset from UTC, in seconds (-18000 = US Eastern Standard Time, -21600 = US Central Standard Time, etc.)
+const int   daylightOffset_sec   = 3600;                    // Number of seconds offset for daylight saving time (0 if daylight savings time if not applicable)
+const char *basicAuthString      = "";                      // If non-empty, require HTTP Basic Authentication for HTTP endpoints.  Format is username:password (Base64 encoded)
+const char *basicAuthAdminString = "YWRtaW46cEBzc3dvcmQ=";  // Admin username + password, Base64 encoded (admin:p@ssword = YWRtaW46cEBzc3dvcmQ=)
 
 #define SERVO_PIN  13
 #define DHT_PIN    14

--- a/src/DayClock/DayClock.ino
+++ b/src/DayClock/DayClock.ino
@@ -159,7 +159,10 @@ void setup()
   static DHT_Unified::Temperature _dht_temperature = dht.temperature();
   sensor_temperature = &_dht_temperature;
 #elif DH_SENSOR_TYPE == AHT_SENSOR_TYPE
-  aht.begin();
+  if(!aht.begin())
+  {
+    Serial.println("Unable to connect to AHT20");
+  }
   sensor_humidity = aht.getHumiditySensor();
   sensor_temperature = aht.getTemperatureSensor();
 #else
@@ -252,6 +255,7 @@ void setup()
   webServer.on("/do_update",   HTTP_POST, [](AsyncWebServerRequest * request) {},
                                           [](AsyncWebServerRequest * request, const String & filename, size_t index, uint8_t *data, size_t len, bool final) {
                                                httpDoUpdateHandler(request, filename, index, data, len, final); });
+  webServer.on("/reset",       HTTP_GET,  httpResetHandler);
 
   DefaultHeaders::Instance().addHeader("Access-Control-Allow-Origin", "*");
   webServer.begin();

--- a/src/DayClock/HTTPHandlers.ino
+++ b/src/DayClock/HTTPHandlers.ino
@@ -617,7 +617,7 @@ void httpDoUpdateHandler(AsyncWebServerRequest *request, const String& filename,
     request->send(400);
     return;    
   }
-    
+  
   if (!index)
   {
     Serial.println("Update Starting");
@@ -713,6 +713,10 @@ void httpResetHandler(AsyncWebServerRequest *request)
     return;
   }
 
+  const char *html = "<html><head><meta http-equiv='refresh' content='10; url=/'><title>Rebooting</title></head><body>Rebooting...</body></html>";
+  request->send(200, "text/html", html);
+  delay(1000);
+  
   ESP.restart();
 }
 

--- a/src/DayClock/HTTPHandlers.ino
+++ b/src/DayClock/HTTPHandlers.ino
@@ -575,6 +575,7 @@ void httpUpdateHandler(AsyncWebServerRequest *request)
   {
     request->send(response);
     log_end_request("/update (missing authentication)");
+    return;
   }
 
   srand(millis());
@@ -709,6 +710,7 @@ void httpResetHandler(AsyncWebServerRequest *request)
   {
     request->send(response);
     log_end_request("/reset (missing authentication)");
+    return;
   }
 
   ESP.restart();


### PR DESCRIPTION
Implemented `authenticationCheck()` and `authenticationAdminCheck()` which use the Base64 encoded username:password values `basicAuthString ` and `basicAuthAdminString` from config.h to add HTTP Basic authentication to the HTTP endpoints.  

Added /reset endpoint
