### PR TITLE
Enable CO2 configuration

### DIFF
--- a/src/DayClock/DayClock.ino
+++ b/src/DayClock/DayClock.ino
@@ -202,7 +202,7 @@ void setup()
   // Initialize MHZ-19B device
   mhz19Serial.begin(MHZ19_BAUDRATE);
   mhz19.begin(mhz19Serial);
-  mhz19.autoCalibration();
+  mhz19.autoCalibration(false);
 
   // Set delay between sensor readings based on sensor details
   delayMS = 5000; //(sensor.min_delay / 1000) * 2;
@@ -256,6 +256,7 @@ void setup()
                                           [](AsyncWebServerRequest * request, const String & filename, size_t index, uint8_t *data, size_t len, bool final) {
                                                httpDoUpdateHandler(request, filename, index, data, len, final); });
   webServer.on("/reset",       HTTP_GET,  httpResetHandler);
+  webServer.on("/calibrate",   HTTP_GET,  httpCalibrateHandler);
 
   DefaultHeaders::Instance().addHeader("Access-Control-Allow-Origin", "*");
   webServer.begin();

--- a/src/DayClock/DayClock.ino
+++ b/src/DayClock/DayClock.ino
@@ -202,7 +202,7 @@ void setup()
   // Initialize MHZ-19B device
   mhz19Serial.begin(MHZ19_BAUDRATE);
   mhz19.begin(mhz19Serial);
-  mhz19.autoCalibration(false);
+  mhz19.autoCalibration(true);
 
   // Set delay between sensor readings based on sensor details
   delayMS = 5000; //(sensor.min_delay / 1000) * 2;
@@ -242,21 +242,22 @@ void setup()
 
   log_free_memory("setup() before webServer");
   
-  webServer.on("/",            HTTP_GET,  httpRootHandler);
-  webServer.on("/xml",         HTTP_GET,  httpXMLHandler);
-  webServer.on("/json",        HTTP_GET,  httpJSONHandler);
-  webServer.on("/favicon.ico", HTTP_GET,  httpFaviconHandler);
+  webServer.on("/",               HTTP_GET,  httpRootHandler);
+  webServer.on("/xml",            HTTP_GET,  httpXMLHandler);
+  webServer.on("/json",           HTTP_GET,  httpJSONHandler);
+  webServer.on("/favicon.ico",    HTTP_GET,  httpFaviconHandler);
 #if HISTORY_COUNT
-  webServer.on("/chart",       HTTP_GET,  httpChartHandler);
-  webServer.on("/history",     HTTP_GET,  httpHistoryHandler);
-  webServer.on("/chart.png",   HTTP_GET,  httpChartIconHandler);
+  webServer.on("/chart",          HTTP_GET,  httpChartHandler);
+  webServer.on("/history",        HTTP_GET,  httpHistoryHandler);
+  webServer.on("/chart.png",      HTTP_GET,  httpChartIconHandler);
 #endif
-  webServer.on("/update",      HTTP_GET,  httpUpdateHandler);
-  webServer.on("/do_update",   HTTP_POST, [](AsyncWebServerRequest * request) {},
-                                          [](AsyncWebServerRequest * request, const String & filename, size_t index, uint8_t *data, size_t len, bool final) {
-                                               httpDoUpdateHandler(request, filename, index, data, len, final); });
-  webServer.on("/reset",       HTTP_GET,  httpResetHandler);
-  webServer.on("/calibrate",   HTTP_GET,  httpCalibrateHandler);
+  webServer.on("/update",         HTTP_GET,  httpUpdateHandler);
+  webServer.on("/do_update",      HTTP_POST, [](AsyncWebServerRequest * request) {},
+                                             [](AsyncWebServerRequest * request, const String & filename, size_t index, uint8_t *data, size_t len, bool final) {
+                                                    httpDoUpdateHandler(request, filename, index, data, len, final); });
+  webServer.on("/reset",          HTTP_GET,  httpResetHandler);
+  webServer.on("/calibrate",      HTTP_GET,  httpCalibrateHandler);
+  webServer.on("/auto_calibrate", HTTP_GET,  httpAutoCalibrateHandler);
 
   DefaultHeaders::Instance().addHeader("Access-Control-Allow-Origin", "*");
   webServer.begin();

--- a/src/DayClock/HTTPHandlers.ino
+++ b/src/DayClock/HTTPHandlers.ino
@@ -724,12 +724,44 @@ void httpCalibrateHandler(AsyncWebServerRequest *request)
 {
   log_start_request(request, "/calibrate");
 
+  AsyncWebServerResponse *response = authenticationAdminCheck(request);
+  if(response != NULL)
+  {
+    request->send(response);
+    log_end_request("/calibrate (missing authentication)");
+    return;
+  }
+  
   mhz19.calibrate();
   const char *html = "<html><head><meta http-equiv='refresh' content='5; url=/'><title>Calibrating</title></head><body>Starting calibration...</body></html>";
   request->send(200, "text/html", html);
   
   log_end_request("/calibrate");
 }
+
+void httpAutoCalibrateHandler(AsyncWebServerRequest *request)
+{
+  log_start_request(request, "/auto_calibrate");
+
+  AsyncWebServerResponse *response = authenticationAdminCheck(request);
+  if(response != NULL)
+  {
+    request->send(response);
+    log_end_request("/auto_calibrate (missing authentication)");
+    return;
+  }
+
+  bool new_abcStatus = mhz19.getABC() ? false : true;
+  mhz19.autoCalibration(new_abcStatus);
+  char buf[160];
+  const char *msg =  mhz19.getABC() ? "Enabled" : "Disabled";
+  snprintf(buf, sizeof(buf) - 1, 
+           "<html><head><meta http-equiv='refresh' content='5; url=/'><title>Auto Calibrate %s</title></head><body>Auto Calibrate %s</body></html>", msg, msg);
+  request->send(200, "text/html", buf);
+  
+  log_end_request("/auto_calibrate");
+}
+
 
 
 AsyncWebServerResponse* authenticationCheck(AsyncWebServerRequest *request)

--- a/src/DayClock/HTTPHandlers.ino
+++ b/src/DayClock/HTTPHandlers.ino
@@ -720,6 +720,18 @@ void httpResetHandler(AsyncWebServerRequest *request)
   ESP.restart();
 }
 
+void httpCalibrateHandler(AsyncWebServerRequest *request)
+{
+  log_start_request(request, "/calibrate");
+
+  mhz19.calibrate();
+  const char *html = "<html><head><meta http-equiv='refresh' content='5; url=/'><title>Calibrating</title></head><body>Starting calibration...</body></html>";
+  request->send(200, "text/html", html);
+  
+  log_end_request("/calibrate");
+}
+
+
 AsyncWebServerResponse* authenticationCheck(AsyncWebServerRequest *request)
 {
   return(authenticationCheck(request, false));


### PR DESCRIPTION
This change adds the /calibrate (to trigger a calibration event) and /auto_calibrate (to toggle the ABC status), both requiring admin credentials. It also explicitly enables the auto configuration by default.